### PR TITLE
Add CI: lint, format check, typecheck, and tests on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+      - feature/batch-api/rc
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: "Lint, typecheck, and test"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Fetch source code"
+        uses: actions/checkout@v4
+
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: "Install dependencies"
+        run: uv sync --all-extras
+
+      - name: "Lint, format check, and typecheck"
+        run: make check
+
+      - name: "Unit tests"
+        run: make test


### PR DESCRIPTION
## Summary
No GitHub Actions existed in this repo at all before this. Adds a single workflow that runs on every PR and on push to `main`/`feature/batch-api/rc`:
- `make check` — ruff lint + format check, `ty` typecheck
- `make test` — pytest

Scoped deliberately to lint/checks/tests only, per request — no publish automation. Based off `feature/batch-api/rc` since that's where `pyproject.toml`/`uv` (which this workflow needs) actually lives; `main` still has the old `setup.py`/`requirements.txt` structure.

## Test plan
- [x] Ran the exact CI steps locally: `uv sync --all-extras`, `make check` (clean), `make test` (123/123 pass)